### PR TITLE
Fix a minor ie flex bug

### DIFF
--- a/src/components/playlist/style.css
+++ b/src/components/playlist/style.css
@@ -30,6 +30,7 @@
 }
 
 .title {
+    flex-shrink: 0; /* devnote: fixes an ie issues with multi-line titles */
     color: inherit;
     font-size: 20px;
     text-decoration: none;


### PR DESCRIPTION
Resolves an issue where multi-line headings would overlap their subtitle (published date) on ie11.